### PR TITLE
Custom error handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "test": "jest --coverage"
   },
   "peerDependencies": {
-    "express": "4.x",
     "@zodios/core": ">=10.4.4 <11.0.0",
+    "express": "4.x",
     "zod": "^3.x"
   },
   "devDependencies": {
+    "@jest/types": "^29.5.0",
     "@types/express": "4.17.17",
     "@types/jest": "29.5.0",
     "@types/node": "18.15.11",
@@ -63,6 +64,5 @@
     "tsup": "6.3.0",
     "typescript": "5.0.3",
     "zod": "3.21.4"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -88,6 +88,17 @@ export type ZodiosRouterContextErrorHandler<Context extends ZodObject<any>> = (
   next: express.NextFunction
 ) => void;
 
+export type ZodiosRouterValidationErrorHandler<Context extends ZodObject<any>> =
+  (
+    error: {
+      context: string;
+      error: z.ZodIssue[];
+    },
+    req: WithZodiosContext<express.Request, Context>,
+    res: express.Response,
+    next: express.NextFunction
+  ) => void;
+
 export interface ZodiosUse<Context extends ZodObject<any>> {
   use(...handlers: Array<ZodiosRouterContextRequestHandler<Context>>): this;
   use(handlers: Array<ZodiosRouterContextRequestHandler<Context>>): this;
@@ -137,6 +148,7 @@ export interface ZodiosAppOptions<Context extends ZodObject<any>>
    */
   enableJsonBodyParser?: boolean;
   context?: Context;
+  validationErrorHandler?: ZodiosRouterValidationErrorHandler<Context>;
 }
 
 export interface ZodiosRouterOptions<Context extends ZodObject<any>>
@@ -146,6 +158,7 @@ export interface ZodiosRouterOptions<Context extends ZodObject<any>>
    */
   router?: ReturnType<typeof express.Router>;
   context?: Context;
+  validationErrorHandler?: ZodiosRouterValidationErrorHandler<Context>;
 }
 
 export type ZodiosApp<


### PR DESCRIPTION
The defaultErrorHandler function takes in the error object and sends a JSON response with a 400 status code and the error object.

The ZodiosRouterValidationErrorHandler type defines a function signature that matches the parameters of defaultErrorHandler. This is for defining custom error handlers that can be passed as the validationErrorHandler parameter to the zodiosRouter function.

```js
function validationErrorHandler(err, req, res, next) {
  throw new InvalidInputError({ fields: err.error.map(convertIssue) });
}
const route = zodiosRouter(api, {
  router: Router(),
  validationErrorHandler,
});
```

#140 