### PR TITLE
Update package.json to include express 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@zodios/core": ">=10.4.4 <11.0.0",
-    "express": "4.x",
+    "express": "4.x || 5.x",
     "zod": "^3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Since there are no breaking changes that are part of this library, it can support Express 5.